### PR TITLE
use-package-always-ensure not workning without require use-package

### DIFF
--- a/emacs_templates/emacs/elisp/base.el
+++ b/emacs_templates/emacs/elisp/base.el
@@ -8,6 +8,7 @@
 
 (unless (package-installed-p 'use-package)
   (package-install 'use-package))
+(require 'use-package)
 
 (defconst private-dir  (expand-file-name "private" user-emacs-directory))
 (defconst temp-dir (format "%s/cache" private-dir)


### PR DESCRIPTION
On emacs 26.1 I had to "require use-package" before the flag "use-package-always-ensure" works. After that I can add packages in base-extensions and they will be ensured.