### PR TITLE
Create missing folder private/cache/auto-save-list if missing.

### DIFF
--- a/emacs_templates/emacs/elisp/base.el
+++ b/emacs_templates/emacs/elisp/base.el
@@ -66,6 +66,9 @@
  backup-directory-alist            `((".*" . ,(concat temp-dir "/backup/")))
  auto-save-file-name-transforms    `((".*" ,(concat temp-dir "/auto-save-list/") t)))
 
+(unless (file-exists-p (concat temp-dir "/auto-save-list"))
+		       (make-directory (concat temp-dir "/auto-save-list") :parents))
+
 (fset 'yes-or-no-p 'y-or-n-p)
 (global-auto-revert-mode t)
 


### PR DESCRIPTION
I had a problem with folders "private", "private/cache" and "private/cache/auto-save-list" not being created if they didn't exist. This solution worked for me.