### PR TITLE
Fixes error message if pyenv is not installed.

### DIFF
--- a/emacs_templates/emacs/elisp/lang-python.el
+++ b/emacs_templates/emacs/elisp/lang-python.el
@@ -27,6 +27,8 @@
 
 
 (use-package pyenv-mode
+  :if
+  (executable-find "pyenv")
   :init
   (add-to-list 'exec-path "~/.pyenv/shims")
   (setenv "WORKON_HOME" "~/.pyenv/versions/")


### PR DESCRIPTION
Fixes error message if pyenv is not installed. Not super important, but I got rid of an error message if I use my .emacs.d on a computer without pyenv.