### PR TITLE
run the project locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+serve: venv
+	. venv/bin/activate ; FLASK_APP=app/application.py flask run
+
+venv:
+	python3 -m venv venv
+	. venv/bin/activate ; python3 -m pip install -r requirements.txt


### PR DESCRIPTION


## Description
A makefile with a `serve` command to run the webapp locally on port 5000
This runs in debug mode, do not expose this to the public net


As a workaround to #53, I wanted to run the app locally so I can still generate these sweet configs. I'm not a python expert so it took me some time to figure out. Wanted to contribute it back in case anyone else had the same idea.


## Usage
- tested with Python 3.8.2
- run `make` in the root folder to download the python dependencies in a venv and run the webapp.
- open browser to http://localhost:5000
- interact with it to download the configs you want to generate.