### PR TITLE
Update Go template to use lsp-mode instead go-mode

### DIFF
--- a/emacs_templates/emacs/elisp/lang-go.el
+++ b/emacs_templates/emacs/elisp/lang-go.el
@@ -1,39 +1,32 @@
-(use-package go-mode
+(use-package lsp-mode
+  :ensure t
+  :commands (lsp lsp-deferred)
+  :hook (go-mode . lsp-deferred))
+
+;; Set up before-save hooks to format buffer and add/delete imports.
+;; Make sure you don't have other gofmt/goimports hooks enabled.
+(defun lsp-go-install-save-hooks ()
+  (add-hook 'before-save-hook #'lsp-format-buffer t t)
+  (add-hook 'before-save-hook #'lsp-organize-imports t t))
+(add-hook 'go-mode-hook #'lsp-go-install-save-hooks)
+
+;; Optional - provides fancier overlays.
+(use-package lsp-ui
+  :ensure t
+  :commands lsp-ui-mode)
+
+;; Company mode is a standard completion package that works well with lsp-mode.
+(use-package company
+  :ensure t
   :config
-  ; Use goimports instead of go-fmt
-  (setq gofmt-command "goimports")
-  (add-hook 'go-mode-hook 'company-mode)
-  ;; Call Gofmt before saving
-  (add-hook 'before-save-hook 'gofmt-before-save)
-  (add-hook 'go-mode-hook 'setup-go-mode-compile)
-  (add-hook 'go-mode-hook #'smartparens-mode)
-  (add-hook 'go-mode-hook '(lambda ()
-			     (local-set-key (kbd "C-c C-r") 'go-remove-unused-imports)))
-  (add-hook 'go-mode-hook '(lambda ()
-			     (local-set-key (kbd "C-c C-g") 'go-goto-imports)))
-  (add-hook 'go-mode-hook (lambda ()
-			    (set (make-local-variable 'company-backends) '(company-go))
-			    (company-mode))))
+  ;; Optionally enable completion-as-you-type behavior.
+  (setq company-idle-delay 0)
+  (setq company-minimum-prefix-length 1))
 
-(use-package company-go
-  :after go-mode
-  :config
-  (setq tab-width 4)
-
-  :bind (:map go-mode-map
-  ; Godef jump key binding
-  ("M-." . godef-jump)))
-
-(use-package flymake-go)
-
-(use-package go-eldoc
-  :config
-  (add-hook 'go-mode-hook 'go-eldoc-setup))
-
-(defun setup-go-mode-compile ()
-  ; Customize compile command to run go build
-  (if (not (string-match "go" compile-command))
-      (set (make-local-variable 'compile-command)
-           "go build -v && go test -v && go vet")))
+;; Optional - provides snippet support.
+(use-package yasnippet
+  :ensure t
+  :commands yas-minor-mode
+  :hook (go-mode . yas-minor-mode))
 
 (provide 'lang-go)


### PR DESCRIPTION
The Emacs behaviour for go.mod using the go-mode is not satisfactory at all. So, I'm sending this PR to adopt the lsp-mode as solution for Go, which has a much better approach to go.mod projects.