### PR TITLE
Change arg name for exporting config

### DIFF
--- a/app/application.py
+++ b/app/application.py
@@ -53,7 +53,7 @@ def generate_configs():
         root_dir=directory,
         base_dir='emacs.d'
     )
-    return send_from_directory(directory=directory, filename='emacs.d.zip')
+    return send_from_directory(directory=directory, path='emacs.d.zip')
 
 
 def _get_theme_package(theme_name):


### PR DESCRIPTION
Tracks change in new Flask API to fix bug on /generate POST:

return send_from_directory(directory=directory, path='emacs.d.zip')
TypeError: send_from_directory() missing 1 required positional argument: 'path'

This is required for the generate command to continue to work with current Flask. See https://stackoverflow.com/questions/67591467/flask-shows-typeerror-send-from-directory-missing-1-required-positional-argum for what this looks like.