### PR TITLE
Go and Python templates fixes

### DIFF
--- a/emacs_templates/emacs/elisp/lang-go.el
+++ b/emacs_templates/emacs/elisp/lang-go.el
@@ -1,3 +1,5 @@
+(use-package go-mode)
+
 (use-package lsp-mode
   :ensure t
   :commands (lsp lsp-deferred)

--- a/emacs_templates/emacs/elisp/lang-python.el
+++ b/emacs_templates/emacs/elisp/lang-python.el
@@ -10,6 +10,7 @@
   (use-package elpy
     :init
     (add-to-list 'auto-mode-alist '("\\.py$" . python-mode))
+	(setq elpy-rpc-python-command "/usr/bin/python3")
     :config
     (setq elpy-rpc-backend "jedi")
     ;; (add-hook 'python-mode-hook 'py-autopep8-enable-on-save)


### PR DESCRIPTION
- Fix go template to recognize go files
- Fix elpy to create initial virtualenv using python 3